### PR TITLE
refactor: 공통 예외 처리 구조 개선

### DIFF
--- a/src/main/java/com/j3s/yobuddy/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/j3s/yobuddy/common/exception/GlobalExceptionHandler.java
@@ -1,35 +1,55 @@
 package com.j3s.yobuddy.common.exception;
 
-import java.time.Instant;
-import java.util.Map;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import java.time.Instant;
+import java.util.HashMap;
+import java.util.Map;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(BusinessException.class)
     public ResponseEntity<?> handleBusinessException(BusinessException e) {
-        return ResponseEntity
-            .status(e.getStatus())
-            .body(Map.of(
-                "timestamp", Instant.now().toString(),
-                "status", e.getStatus().value(),
-                "error", e.getStatus().getReasonPhrase(),
-                "message", e.getMessage()
-            ));
+        return buildErrorResponse(e.getStatus(), e.getMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<?> handleValidation(MethodArgumentNotValidException e) {
+        Map<String, String> fieldErrors = new HashMap<>();
+        for (FieldError err : e.getBindingResult().getFieldErrors()) {
+            fieldErrors.put(err.getField(), err.getDefaultMessage());
+        }
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, "입력값이 유효하지 않습니다.", fieldErrors);
+    }
+
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<?> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
+        return buildErrorResponse(HttpStatus.BAD_REQUEST, "요청 파라미터 형식이 올바르지 않습니다.");
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<?> handleGenericException(Exception e) {
-        return ResponseEntity
-            .internalServerError()
-            .body(Map.of(
-                "timestamp", Instant.now().toString(),
-                "status", 500,
-                "error", "Internal Server Error",
-                "message", e.getMessage()
-            ));
+        return buildErrorResponse(HttpStatus.INTERNAL_SERVER_ERROR, e.getMessage());
+    }
+
+    private ResponseEntity<Map<String, Object>> buildErrorResponse(HttpStatus status, String message) {
+        return buildErrorResponse(status, message, null);
+    }
+
+    private ResponseEntity<Map<String, Object>> buildErrorResponse(HttpStatus status, String message, Object details) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("timestamp", Instant.now().toString());
+        body.put("status", status.value());
+        body.put("error", status.getReasonPhrase());
+        body.put("message", message);
+        if (details != null) body.put("details", details);
+        return ResponseEntity.status(status).body(body);
     }
 }


### PR DESCRIPTION
## 📌 작업 내용

* `GlobalExceptionHandler` 전면 리팩토링

  * `BusinessException` 기반 예외를 상태 코드별로 세분화 처리 (`404`, `409`, 등)
  * `MethodArgumentNotValidException` 처리 추가 → DTO 유효성 검증 실패 시 `400 Bad Request` 반환
  * `MethodArgumentTypeMismatchException` 처리 추가 → 파라미터 타입 오류 시 `400 Bad Request` 반환
  * 일반 `Exception`은 `500 Internal Server Error` 로 통일
* 예외 응답 포맷을 일관화 (`timestamp`, `status`, `error`, `message`, `details`)

---

## ✅ 작업 브랜치

* `refactor/globalexceptionhandler`

---

## 📷 스크린샷 (선택)

예외 응답 예시:

```json
{
  "timestamp": "2025-11-03T14:20:00Z",
  "status": 400,
  "error": "Bad Request",
  "message": "입력값이 유효하지 않습니다.",
  "details": {
    "name": "프로그램명은 필수입니다."
  }
}
```

close #8 