### PR TITLE
feat: 프로그램 참여(Program Enrollment) CRUD 및 예외처리 구현

### DIFF
--- a/src/main/java/com/j3s/yobuddy/domain/programenrollment/controller/ProgramEnrollmentController.java
+++ b/src/main/java/com/j3s/yobuddy/domain/programenrollment/controller/ProgramEnrollmentController.java
@@ -1,0 +1,49 @@
+package com.j3s.yobuddy.domain.programenrollment.controller;
+
+import com.j3s.yobuddy.domain.programenrollment.dto.request.ProgramEnrollmentRequest;
+import com.j3s.yobuddy.domain.programenrollment.dto.request.ProgramEnrollmentUpdateRequest;
+import com.j3s.yobuddy.domain.programenrollment.dto.response.ProgramEnrollmentResponse;
+import com.j3s.yobuddy.domain.programenrollment.service.ProgramEnrollmentService;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/enrollments")
+public class ProgramEnrollmentController {
+
+    private final ProgramEnrollmentService enrollmentService;
+
+    @PostMapping
+    public ResponseEntity<ProgramEnrollmentResponse> enroll(@Valid @RequestBody ProgramEnrollmentRequest request) {
+        return ResponseEntity.ok(enrollmentService.enroll(request));
+    }
+
+    @GetMapping("/program/{programId}")
+    public ResponseEntity<List<ProgramEnrollmentResponse>> getByProgram(@PathVariable Long programId) {
+        return ResponseEntity.ok(enrollmentService.getByProgram(programId));
+    }
+
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<List<ProgramEnrollmentResponse>> getByUser(@PathVariable Long userId) {
+        return ResponseEntity.ok(enrollmentService.getByUser(userId));
+    }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<ProgramEnrollmentResponse> updateEnrollment(
+        @PathVariable Long id,
+        @Valid @RequestBody ProgramEnrollmentUpdateRequest request
+    ) {
+        ProgramEnrollmentResponse response = enrollmentService.updateEnrollment(id, request);
+        return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> withdraw(@PathVariable Long id) {
+        enrollmentService.withdraw(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/j3s/yobuddy/domain/programenrollment/dto/request/ProgramEnrollmentRequest.java
+++ b/src/main/java/com/j3s/yobuddy/domain/programenrollment/dto/request/ProgramEnrollmentRequest.java
@@ -1,0 +1,18 @@
+package com.j3s.yobuddy.domain.programenrollment.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class ProgramEnrollmentRequest {
+
+    @NotNull(message = "프로그램 ID는 필수입니다.")
+    private Long programId;
+
+    @NotNull(message = "사용자 ID는 필수입니다.")
+    private Long userId;
+}

--- a/src/main/java/com/j3s/yobuddy/domain/programenrollment/dto/request/ProgramEnrollmentUpdateRequest.java
+++ b/src/main/java/com/j3s/yobuddy/domain/programenrollment/dto/request/ProgramEnrollmentUpdateRequest.java
@@ -1,0 +1,15 @@
+package com.j3s.yobuddy.domain.programenrollment.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProgramEnrollmentUpdateRequest {
+
+    @NotBlank(message = "상태 값은 필수입니다.")
+    private String status;
+}

--- a/src/main/java/com/j3s/yobuddy/domain/programenrollment/dto/response/ProgramEnrollmentResponse.java
+++ b/src/main/java/com/j3s/yobuddy/domain/programenrollment/dto/response/ProgramEnrollmentResponse.java
@@ -1,0 +1,16 @@
+package com.j3s.yobuddy.domain.programenrollment.dto.response;
+
+import com.j3s.yobuddy.domain.programenrollment.entity.ProgramEnrollment.EnrollmentStatus;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ProgramEnrollmentResponse {
+    private Long enrollmentId;
+    private Long programId;
+    private Long userId;
+    private EnrollmentStatus status;
+    private LocalDateTime enrolledAt;
+}

--- a/src/main/java/com/j3s/yobuddy/domain/programenrollment/entity/ProgramEnrollment.java
+++ b/src/main/java/com/j3s/yobuddy/domain/programenrollment/entity/ProgramEnrollment.java
@@ -1,0 +1,61 @@
+package com.j3s.yobuddy.domain.programenrollment.entity;
+
+import com.j3s.yobuddy.domain.onboarding.entity.OnboardingPrograms;
+import com.j3s.yobuddy.domain.user.entity.Users;
+import jakarta.persistence.*;
+import java.time.LocalDateTime;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "program_enrollment")
+public class ProgramEnrollment {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "enrollment_id")
+    private Long enrollmentId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "program_id", nullable = false)
+    private OnboardingPrograms program;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private Users user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private EnrollmentStatus status;
+
+    @Column(name = "enrolled_at", nullable = false)
+    private LocalDateTime enrolledAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.enrolledAt = LocalDateTime.now();
+        this.createdAt = LocalDateTime.now();
+        this.updatedAt = LocalDateTime.now();
+        if (this.status == null) {
+            this.status = EnrollmentStatus.ACTIVE;
+        }
+    }
+
+    public void updateStatus(EnrollmentStatus status) {
+        this.status = status;
+        this.updatedAt = LocalDateTime.now();
+    }
+
+    public enum EnrollmentStatus {
+        ACTIVE, COMPLETED, WITHDRAWN
+    }
+}

--- a/src/main/java/com/j3s/yobuddy/domain/programenrollment/exception/DuplicateEnrollmentException.java
+++ b/src/main/java/com/j3s/yobuddy/domain/programenrollment/exception/DuplicateEnrollmentException.java
@@ -1,0 +1,10 @@
+package com.j3s.yobuddy.domain.programenrollment.exception;
+
+import com.j3s.yobuddy.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class DuplicateEnrollmentException extends BusinessException {
+    public DuplicateEnrollmentException(Long userId, Long programId) {
+        super("이미 등록된 사용자입니다. (userId=" + userId + ", programId=" + programId + ")", HttpStatus.CONFLICT);
+    }
+}

--- a/src/main/java/com/j3s/yobuddy/domain/programenrollment/exception/EnrollmentNotFoundException.java
+++ b/src/main/java/com/j3s/yobuddy/domain/programenrollment/exception/EnrollmentNotFoundException.java
@@ -1,0 +1,10 @@
+package com.j3s.yobuddy.domain.programenrollment.exception;
+
+import com.j3s.yobuddy.common.exception.BusinessException;
+import org.springframework.http.HttpStatus;
+
+public class EnrollmentNotFoundException extends BusinessException {
+    public EnrollmentNotFoundException(Long id) {
+        super("해당 참여 내역을 찾을 수 없습니다. (id=" + id + ")", HttpStatus.NOT_FOUND);
+    }
+}

--- a/src/main/java/com/j3s/yobuddy/domain/programenrollment/repository/ProgramEnrollmentRepository.java
+++ b/src/main/java/com/j3s/yobuddy/domain/programenrollment/repository/ProgramEnrollmentRepository.java
@@ -1,0 +1,15 @@
+package com.j3s.yobuddy.domain.programenrollment.repository;
+
+import com.j3s.yobuddy.domain.programenrollment.entity.ProgramEnrollment;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ProgramEnrollmentRepository extends JpaRepository<ProgramEnrollment, Long> {
+    List<ProgramEnrollment> findByProgram_ProgramId(Long programId);
+    List<ProgramEnrollment> findByUser_UserId(Long userId);
+    boolean existsByUser_UserIdAndProgram_ProgramId(Long userId, Long programId);
+    Optional<ProgramEnrollment> findByEnrollmentId(Long id);
+}

--- a/src/main/java/com/j3s/yobuddy/domain/programenrollment/service/ProgramEnrollmentService.java
+++ b/src/main/java/com/j3s/yobuddy/domain/programenrollment/service/ProgramEnrollmentService.java
@@ -1,0 +1,14 @@
+package com.j3s.yobuddy.domain.programenrollment.service;
+
+import com.j3s.yobuddy.domain.programenrollment.dto.request.ProgramEnrollmentRequest;
+import com.j3s.yobuddy.domain.programenrollment.dto.request.ProgramEnrollmentUpdateRequest;
+import com.j3s.yobuddy.domain.programenrollment.dto.response.ProgramEnrollmentResponse;
+import java.util.List;
+
+public interface ProgramEnrollmentService {
+    ProgramEnrollmentResponse enroll(ProgramEnrollmentRequest request);
+    List<ProgramEnrollmentResponse> getByProgram(Long programId);
+    List<ProgramEnrollmentResponse> getByUser(Long userId);
+    ProgramEnrollmentResponse updateEnrollment(Long id, ProgramEnrollmentUpdateRequest request);
+    void withdraw(Long id);
+}

--- a/src/main/java/com/j3s/yobuddy/domain/programenrollment/service/ProgramEnrollmentServiceImpl.java
+++ b/src/main/java/com/j3s/yobuddy/domain/programenrollment/service/ProgramEnrollmentServiceImpl.java
@@ -1,0 +1,115 @@
+package com.j3s.yobuddy.domain.programenrollment.service;
+
+import com.j3s.yobuddy.domain.onboarding.entity.OnboardingPrograms;
+import com.j3s.yobuddy.domain.onboarding.repository.OnboardingProgramRepository;
+import com.j3s.yobuddy.domain.programenrollment.dto.request.ProgramEnrollmentRequest;
+import com.j3s.yobuddy.domain.programenrollment.dto.request.ProgramEnrollmentUpdateRequest;
+import com.j3s.yobuddy.domain.programenrollment.dto.response.ProgramEnrollmentResponse;
+import com.j3s.yobuddy.domain.programenrollment.entity.ProgramEnrollment;
+import com.j3s.yobuddy.domain.programenrollment.entity.ProgramEnrollment.EnrollmentStatus;
+import com.j3s.yobuddy.domain.programenrollment.exception.DuplicateEnrollmentException;
+import com.j3s.yobuddy.domain.programenrollment.exception.EnrollmentNotFoundException;
+import com.j3s.yobuddy.domain.programenrollment.repository.ProgramEnrollmentRepository;
+import com.j3s.yobuddy.domain.user.entity.Users;
+import com.j3s.yobuddy.domain.user.repository.UserRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ProgramEnrollmentServiceImpl implements ProgramEnrollmentService {
+
+    private final ProgramEnrollmentRepository enrollmentRepository;
+    private final OnboardingProgramRepository programRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public ProgramEnrollmentResponse enroll(ProgramEnrollmentRequest request) {
+        if (enrollmentRepository.existsByUser_UserIdAndProgram_ProgramId(request.getUserId(), request.getProgramId())) {
+            throw new DuplicateEnrollmentException(request.getUserId(), request.getProgramId());
+        }
+
+        Users user = userRepository.findById(request.getUserId())
+                                  .orElseThrow(() -> new EnrollmentNotFoundException(request.getUserId()));
+        OnboardingPrograms program = programRepository.findById(request.getProgramId())
+                                                      .orElseThrow(() -> new EnrollmentNotFoundException(request.getProgramId()));
+
+        ProgramEnrollment enrollment = ProgramEnrollment.builder()
+                                                        .user(user)
+                                                        .program(program)
+                                                        .status(EnrollmentStatus.ACTIVE)
+                                                        .build();
+
+        ProgramEnrollment saved = enrollmentRepository.save(enrollment);
+
+        return ProgramEnrollmentResponse.builder()
+                                        .enrollmentId(saved.getEnrollmentId())
+                                        .programId(program.getProgramId())
+                                        .userId(user.getUserId())
+                                        .status(saved.getStatus())
+                                        .enrolledAt(saved.getEnrolledAt())
+                                        .build();
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ProgramEnrollmentResponse> getByProgram(Long programId) {
+        return enrollmentRepository.findByProgram_ProgramId(programId)
+                                   .stream()
+                                   .map(e -> ProgramEnrollmentResponse.builder()
+                                                                      .enrollmentId(e.getEnrollmentId())
+                                                                      .programId(e.getProgram().getProgramId())
+                                                                      .userId(e.getUser().getUserId())
+                                                                      .status(e.getStatus())
+                                                                      .enrolledAt(e.getEnrolledAt())
+                                                                      .build())
+                                   .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional(readOnly = true)
+    public List<ProgramEnrollmentResponse> getByUser(Long userId) {
+        return enrollmentRepository.findByUser_UserId(userId)
+                                   .stream()
+                                   .map(e -> ProgramEnrollmentResponse.builder()
+                                                                      .enrollmentId(e.getEnrollmentId())
+                                                                      .programId(e.getProgram().getProgramId())
+                                                                      .userId(e.getUser().getUserId())
+                                                                      .status(e.getStatus())
+                                                                      .enrolledAt(e.getEnrolledAt())
+                                                                      .build())
+                                   .collect(Collectors.toList());
+    }
+
+    @Override
+    @Transactional
+    public ProgramEnrollmentResponse updateEnrollment(Long id, ProgramEnrollmentUpdateRequest request) {
+        ProgramEnrollment enrollment = enrollmentRepository.findById(id)
+                                                           .orElseThrow(() -> new EnrollmentNotFoundException(id));
+
+        enrollment.updateStatus(EnrollmentStatus.valueOf(request.getStatus()));
+        enrollmentRepository.save(enrollment);
+
+        return ProgramEnrollmentResponse.builder()
+                                        .enrollmentId(enrollment.getEnrollmentId())
+                                        .programId(enrollment.getProgram().getProgramId())
+                                        .userId(enrollment.getUser().getUserId())
+                                        .status(enrollment.getStatus())
+                                        .enrolledAt(enrollment.getEnrolledAt())
+                                        .build();
+    }
+
+    @Override
+    @Transactional
+    public void withdraw(Long id) {
+        ProgramEnrollment enrollment = enrollmentRepository.findById(id)
+                                                           .orElseThrow(() -> new EnrollmentNotFoundException(id));
+
+        enrollment.updateStatus(EnrollmentStatus.WITHDRAWN);
+        enrollmentRepository.save(enrollment);
+    }
+}


### PR DESCRIPTION
## 📌 작업 내용
- `api/v1/enrollments` 엔드포인트 추가
- 프로그램 참여(Enrollment) CRUD 기능 구현
  - 참여 등록 (POST)
  - 프로그램별 / 사용자별 조회 (GET)
  - 참여 상태 변경 (PATCH)
  - 참여 철회 (DELETE)
- `DuplicateEnrollmentException`, `EnrollmentNotFoundException` 등 예외 처리 적용
- `GlobalExceptionHandler` 연동으로 일관된 에러 응답 구조 확립

## ✅ 작업 브랜치
- feature/program-enrollment
